### PR TITLE
1 add install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@ __pycache__
 
 .mypy_cache
 .pytest_cache
-.venv
+.venv*
 .vscode
+.tox
 
 dist
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+        args:
+          - --allow-multiple-documents
+      - id: debug-statements
+      - id: detect-private-key
+      - id: forbid-new-submodules
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: 22.8.0
+    hooks:
+      - id: black
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,4 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
+        args: [--max-line-length=88]  # same as black

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ based on a hash value for the object. This means the result is deterministic:
 the same value will always result in the same color (so long as the hash
 function remains deterministic).
 
-This module is a port of the [color-hash Javascript library](https://github.com/zenozeng/color-hash). It supports
-Python 3.4+.
+This module is a port of the [color-hash Javascript library](https://github.com/zenozeng/color-hash).
+It supports Python 3.6+.
 
 ## Quick Start
 
@@ -23,8 +23,19 @@ Python 3.4+.
 '#2dd24b'
 ```
 
+## Installation
+
+Its hosted on PyPI.
+
+```bash
+pip install colorhash
+```
+
 ## Changelog
 
+- color-hash 1.1.0 *(2022-09-01)*
+  - Add tests
+  - Add installation instructions
 - color-hash 1.0.4 *(2021-11-30)*
   - Support only for python 3.6+
   - Add tests

--- a/colorhash/colorhash.py
+++ b/colorhash/colorhash.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2016 Felix Krull <f_krull@gmx.de>
-# Released under the terms of the MIT license; see README.rst.
+# Released under the terms of the MIT license; see README.md.
 
 """
 Generate a color based on an object's hash value.
@@ -16,13 +16,14 @@ Quick start:
 >>> c.hex
 '#2dd24b'
 """
+from __future__ import annotations
+
 from binascii import crc32
 from numbers import Number
 from typing import Any
-from typing import Tuple
 
 
-def crc32_hash(obj: Any):
+def crc32_hash(obj: Any) -> int:
     """
     Generate a hash for ``obj``.
 
@@ -35,7 +36,7 @@ def crc32_hash(obj: Any):
     return crc32(bs) & 0xFFFFFFFF
 
 
-def hsl2rgb(hsl: Tuple[int, float, float]):
+def hsl2rgb(hsl: tuple[int | float, int | float, int | float]) -> tuple[int, int, int]:
     """
     Convert an HSL color value into RGB.
 
@@ -43,17 +44,14 @@ def hsl2rgb(hsl: Tuple[int, float, float]):
     (255, 0, 0)
     """
     try:
-        h, s, l = hsl
-    except TypeError:
-        raise ValueError(hsl)
-    try:
+        h, s, l = hsl  # noqa, I tolerate "l"
         h /= 360
         q = l * (1 + s) if l < 0.5 else l + s - l * s
         p = 2 * l - q
     except TypeError:
         raise ValueError(hsl)
 
-    rgb = []
+    rgb: list[int] = []
     for c in (h + 1 / 3, h, h - 1 / 3):
         if c < 0:
             c += 1
@@ -70,10 +68,10 @@ def hsl2rgb(hsl: Tuple[int, float, float]):
             c = p
         rgb.append(round(c * 255))
 
-    return tuple(rgb)
+    return tuple(rgb)  # noqa
 
 
-def rgb2hex(rgb: Tuple[int, int, int]):
+def rgb2hex(rgb: tuple[int, int, int]) -> str:
     """
     Format an RGB color value into a hexadecimal color string.
 
@@ -93,7 +91,7 @@ def color_hash(
     saturation=(0.35, 0.5, 0.65),
     min_h=None,
     max_h=None,
-):
+) -> tuple[int, float, float]:
     """
     Calculate the color for the given object.
 
@@ -130,7 +128,7 @@ def color_hash(
     hash //= 360
     s = saturation[hash % len(saturation)]
     hash //= len(saturation)
-    l = lightness[hash % len(lightness)]
+    l = lightness[hash % len(lightness)]  # noqa, I tolerate "l"
 
     return (h, s, l)
 
@@ -148,12 +146,12 @@ class ColorHash:
     """
 
     def __init__(self, *args, **kwargs):
-        self.hsl = color_hash(*args, **kwargs)
+        self.hsl: tuple[int, float, float] = color_hash(*args, **kwargs)
 
     @property
-    def rgb(self):
+    def rgb(self) -> tuple[int, int, int]:
         return hsl2rgb(self.hsl)
 
     @property
-    def hex(self):
+    def hex(self) -> str:
         return rgb2hex(self.rgb)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,33 +1,30 @@
 [tool.poetry]
 name = "colorhash"
-version = "1.0.4"
+version = "1.1.0"
 description = "Generate color based on any object"
-authors = [
-    "dimostenis",
-    "Felix Krull <f_krull@gmx.de>"
-    ]
+authors = ["dimostenis <dimosh3k@gmail.com>", "Felix Krull <f_krull@gmx.de>"]
 license = "MIT"
-include = [
-    "README.md",
-    ]
+include = ["README.md"]
 
 readme = "README.md"
 homepage = "https://github.com/dimostenis/color-hash-python"
 repository = "https://pypi.org/project/colorhash/"
 
-keywords = ["color", "hash"]
+keywords = ["color", "hash", "rgb", "hsl", "hex"]
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/dimostenis/color-hash-python/issues"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = ">=3.6.2,<4.0"
 
 [tool.poetry.dev-dependencies]
-mypy = "^0.782"
-flake8 = "^3.8.3"
-black = "^20.8b1"
-pytest = "^6.2.5"
+black = "*"
+flake8 = "*"
+mypy = "*"
+pre-commit = "*"
+pytest = "^6"
+tox = "^3"
 
 [tool.isort]
 profile = "black"
@@ -36,6 +33,17 @@ force_single_line = true
 
 [tool.black]
 line-length = 88
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+isolated_build = True
+envlist = python3.6,python3.7,python3.8,python3.9,python3.10
+
+[testenv]
+deps = pytest
+commands = pytest
+"""
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/test/test_colorhash.py
+++ b/test/test_colorhash.py
@@ -1,17 +1,21 @@
-from pytest import fixture
+import pytest
 
 from colorhash import ColorHash
 
 
-@fixture
+@pytest.fixture
 def objs():
     return (
         "foo",
         "bar",
         None,
-        [0, 1],
         {1, 2},
+        [0, 1],
+        ["a", "list"],
         {"a": 0},
+        {"a": "dict"},
+        ("a", "tuple"),
+        {"a", "set"},
         ColorHash("w00t"),
     )
 
@@ -19,10 +23,53 @@ def objs():
 def test_colorhash_returns_some_color(objs):
 
     for obj in objs:
-        assert isinstance(ColorHash(obj).hex, str)
+        hex = ColorHash(obj).hex
+        assert isinstance(hex, str)
+
+        hsl = ColorHash(obj).hsl
+        assert isinstance(hsl, tuple)
+        assert len(hsl) == 3
+        assert hsl[0] <= 360
+        assert hsl[1] <= 100
+        assert hsl[2] <= 100
+
+        rgb = ColorHash(obj).rgb
+        assert isinstance(rgb, tuple)
+        assert len(rgb) == 3
+        assert all([0 < x <= 255 for x in rgb])
 
 
 def test_colorhash_is_deterministic(objs):
 
     for obj in objs:
         assert ColorHash(obj).hex == ColorHash(obj).hex
+        assert ColorHash(obj).hsl == ColorHash(obj).hsl
+        assert ColorHash(obj).rgb == ColorHash(obj).rgb
+
+
+@pytest.mark.parametrize(
+    ["hsl", "rgb"],
+    (
+        ((0, 1.0, 0.5), (255, 0, 0)),  # red
+        ((240, 1.0, 0.5), (0, 0, 255)),  # blue
+        ((0, 0.0, 0.0), (0, 0, 0)),  # black
+    ),
+)
+def test_hsl2rgb(hsl, rgb):
+    from colorhash.colorhash import hsl2rgb
+
+    assert hsl2rgb(hsl=hsl) == rgb
+
+
+@pytest.mark.parametrize(
+    ["rgb", "hex"],
+    (
+        ((255, 0, 0), "#ff0000"),  # red
+        ((0, 0, 255), "#0000ff"),  # blue
+        ((0, 0, 0), "#000000"),  # black
+    ),
+)
+def test_rgb2hex(rgb, hex):
+    from colorhash.colorhash import rgb2hex
+
+    assert rgb2hex(rgb=rgb) == hex


### PR DESCRIPTION
Add installation instructions as pointed in https://github.com/dimostenis/color-hash-python/issues/1.

Also, added few tests for conversions (`hsl`->`rgb`, `rgb`->`hex`).